### PR TITLE
A fix for issue #16

### DIFF
--- a/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
+++ b/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
@@ -263,6 +263,12 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                                 if (closed) {
                                     break;
                                 }
+                            } catch (Exception e) {
+                                if (!closed) {
+                                    logger.error("failed to get next bulk message, reconnecting...", e);
+                                }
+                                cleanup(0, "failed to get message");
+                                break;
                             }
                         }
 


### PR DESCRIPTION
...same way it is being done for the earlier nextDelivery call on the consumer prior to the bulk requester getting involved. This fixes the problem of getting a shutdown exception that isn't handled and causes the thread to die without cleaning up the channel.
