### PR TITLE
Wrap exchangeDeclare with conditional rather than queueBind

### DIFF
--- a/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
+++ b/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
@@ -216,15 +216,15 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                 QueueingConsumer consumer = new QueueingConsumer(channel);
                 // define the queue
                 try {
-                    channel.exchangeDeclare(rabbitExchange/*exchange*/, rabbitExchangeType/*type*/, rabbitExchangeDurable);
+                    if (rabbitExchangeDeclare) {
+                        // only declare the exchange if we should
+                        channel.exchangeDeclare(rabbitExchange/*exchange*/, rabbitExchangeType/*type*/, rabbitExchangeDurable);
+                    }
                     if (rabbitQueueDeclare) {
                         // only declare the queue if we should
                         channel.queueDeclare(rabbitQueue/*queue*/, rabbitQueueDurable/*durable*/, false/*exclusive*/, rabbitQueueAutoDelete/*autoDelete*/, rabbitQueueArgs/*extra args*/);
                     }
-                    if (rabbitExchangeDeclare) {
-                        // only declare the exchange if we should
-                        channel.queueBind(rabbitQueue/*queue*/, rabbitExchange/*exchange*/, rabbitRoutingKey/*routingKey*/);
-                    }
+                    channel.queueBind(rabbitQueue/*queue*/, rabbitExchange/*exchange*/, rabbitRoutingKey/*routingKey*/);
                     channel.basicConsume(rabbitQueue/*queue*/, false/*noAck*/, consumer);
                 } catch (Exception e) {
                     if (!closed) {


### PR DESCRIPTION
I was trying to convince river-rabbitmq not to declare the exchange it was connecting to (because one side was declaring it as direct and the other as fanout, and I was hacking around trying to fix it), but not having any luck.

Checking out the code, I suspect the if statement avoiding declaring the exchange it wrapping the wrong method, so I've tweaked it. I'm not a Java developer, nor am I terribly familiar with RabbitMQ's API, nor have I even tried my fix, so I might be talking nonsense!

But I thought I'd highlight it just in case... 
