### PR TITLE
Error management 1.4.0

### DIFF
--- a/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
+++ b/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
@@ -265,6 +265,7 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                             try {
                                 while ((task = consumer.nextDelivery(bulkTimeout.millis())) != null) {
                                     try {
+                                        bodies.add(task.getBody());
                                         bulkRequestBuilder.add(task.getBody(), 0, task.getBody().length, false);
                                         deliveryTags.add(task.getEnvelope().getDeliveryTag());
                                     } catch (Exception e) {


### PR DESCRIPTION
Several changes to improve the reliability of river-rabbitmq, based on the excellent work of zauberlabs.  This branch won't merge cleanly because it's based on 1.4.0, but nevertheless I thought you might find it interesting.  It adds:

* Shunting of failed documents to a separate queue in elasticsearch for manual recovery.
* Exponential backoff and retry to decrease the likelihood of failure.

Tested against 0.90.1.