### PR TITLE
Allow setting QoS parameters like prefetch size and count.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ curl -XPUT 'localhost:9200/_river/my_river/_meta' -d '{
         "queue_bind" : true,
         "queue_durable" : true,
         "queue_auto_delete" : false,
+        "qos_prefetch_size" : 0,
+        "qos_prefetch_count" : 10,
         "heartbeat" : "30m"
     },
     "index" : {

--- a/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
+++ b/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
@@ -68,6 +68,8 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
     private final boolean rabbitExchangeDeclare;
     private final boolean rabbitQueueDurable;
     private final boolean rabbitQueueAutoDelete;
+    private final int rabbitQosPrefetchSize;
+    private final int rabbitQosPrefetchCount;
     private Map rabbitQueueArgs = null; //extra arguments passed to queue for creation (ha settings for example)
     private final TimeValue rabbitHeartbeat;
 
@@ -137,6 +139,9 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
             }
             rabbitQueueBind = XContentMapValues.nodeBooleanValue(rabbitSettings.get("queue_bind"), true);
 
+            rabbitQosPrefetchSize = XContentMapValues.nodeIntegerValue(rabbitSettings.get("qos_prefetch_size"), 0);
+            rabbitQosPrefetchCount = XContentMapValues.nodeIntegerValue(rabbitSettings.get("qos_prefetch_count"), 10);
+
             rabbitHeartbeat = TimeValue.parseTimeValue(XContentMapValues.nodeStringValue(
                     rabbitSettings.get("heartbeat"), "30m"), TimeValue.timeValueMinutes(30));
 
@@ -157,6 +162,9 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
             rabbitExchangeDeclare = true;
             rabbitQueueDeclare = true;
             rabbitQueueBind = true;
+
+            rabbitQosPrefetchSize = 0;
+            rabbitQosPrefetchCount = 10;
 
             rabbitHeartbeat = TimeValue.timeValueMinutes(30);
         }
@@ -288,6 +296,7 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                         // only bind queue if we should
                         channel.queueBind(rabbitQueue/*queue*/, rabbitExchange/*exchange*/, rabbitRoutingKey/*routingKey*/);
                     }
+                    channel.basicQos(rabbitQosPrefetchSize/*qos_prefetch_size*/, rabbitQosPrefetchCount/*qos_prefetch_count*/, false);
                     channel.basicConsume(rabbitQueue/*queue*/, false/*noAck*/, consumer);
                 } catch (Exception e) {
                     if (!closed) {


### PR DESCRIPTION
Added ability to configure pre-fetch parameter of rabbit-mq and set pre-fetch count to 10 as default.

Why is it needed in the first place:
Without pre-fetch parameters the rabbit-mq river will attempt to download all messages locally on the elastic search instance. So if you have a large amount of messages on queue the elastic search instance will OOM itself to death just trying to be clever and pre-fetching everything (which is the default behavior of the rabbit-mq client). Restarting won't do much good since it's only going to OOM again.. In poetic terms: the river's gonna drown the elastics.

10 as default:
It's a value we've arrived at after couple of years of using rabbit-mq on EC2 for all sorts of purposes. 10 protects you from losing messages and drowning instances. Increasing it seldom gives any meaningful performance benefits. If one seriously needs performance it is far better to batch and pre-compile messages before putting them on the mq.
