### PR TITLE
Nack messages when a bulk execution throws an exception.

### DIFF
--- a/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
+++ b/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
@@ -384,6 +384,13 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                                 }
                             } catch (Exception e) {
                                 logger.warn("failed to execute bulk", e);
+                                for (Long deliveryTag : deliveryTags) {
+                                    try {
+                                        channel.basicNack(deliveryTag, false, false);
+                                    } catch (Exception e1) {
+                                        logger.warn("failed to nack [{}]", e1, deliveryTag);
+                                    }
+                                }
                             }
                         } else {
                             if (bulkRequestBuilder.numberOfActions()>0) {
@@ -405,7 +412,14 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                                     
                                     @Override
                                     public void onFailure(Throwable e) {
-                                        logger.warn("failed to execute bulk for delivery tags [{}], not ack'ing", e, deliveryTags);
+                                        logger.warn("failed to execute bulk for delivery tags [{}], nack'ing", e, deliveryTags);
+                                        for (Long deliveryTag : deliveryTags) {
+                                            try {
+                                                channel.basicNack(deliveryTag, false, false);
+                                            } catch (Exception e1) {
+                                                logger.warn("failed to nack [{}]", e1, deliveryTag);
+                                            }
+                                        }
                                     }
                                 });
                             }


### PR DESCRIPTION
Nack failed messages when the ElasticSearch client throws an exception so they don't cause RabbitMQ to fill its memory.
