### PR TITLE
Set the basic QOS on a channel to avoid infinite prefetching.

### DIFF
--- a/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
+++ b/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
@@ -255,6 +255,7 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                 try {
                     connection = connectionFactory.newConnection(rabbitAddresses);
                     channel = connection.createChannel();
+                    channel.basicQos(bulkSize * 2);
                 } catch (Exception e) {
                     if (!closed) {
                         logger.warn("failed to created a connection / channel", e);


### PR DESCRIPTION
Without executing `Channel.basicQos()`, ElasticSearch's RabbitMQ client will prefetch an infinite number of messages from the queue and eventually run out of heap space.

This patch limits the prefetched messages to twice the amount specified by the river's `bulk_size`.

It might make sense to make this a configuration option as either an absolute number or multiple.
