### PR TITLE
Update README.md, added note where to search when timeouts occur.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ curl -XPUT 'localhost:9200/_river/my_river/_meta' -d '{
 }'
 ```
 
+***Note: creating an elasticsearch river times out and fails if not all shards are up***
+
 You can disable exchange or queue declaration by setting `exchange_declare` or `queue_declare` to `false`
 (`true` by default).
 You can disable queue binding by setting `queue_bind` to `false` (`true` by default).


### PR DESCRIPTION
Took me half a day to figure out, that creating a river fails when not all shards are up. Added note to create river section.
This could actually also be added to the logstash elasticsearch_river output documentation.
