### PR TITLE
make the action data available to the filter script

### DIFF
--- a/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
+++ b/src/main/java/org/elasticsearch/river/rabbitmq/RabbitmqRiver.java
@@ -545,6 +545,7 @@ public class RabbitmqRiver extends AbstractRiverComponent implements River {
                         continue;
                     }
                     script.setNextVar("ctx", ctx);
+                    script.setNextVar("action", asMap);
                     script.run();
                     ctx = (Map<String, Object>) script.unwrap(ctx);
                     if (ctx != null) {


### PR DESCRIPTION
I have a script which needs to known the _index the document is being indexed to, so it needs the data from the "action" line of the bulk request
