### PR TITLE
Make the action data available to the filter script

### DIFF
--- a/src/test/java/org/elasticsearch/river/rabbitmq/RabbitMQIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/river/rabbitmq/RabbitMQIntegrationTest.java
@@ -328,6 +328,41 @@ public class RabbitMQIntegrationTest extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void testInlineScriptWithAdditionalInfos() throws Exception {
+        launchTest(jsonBuilder()
+                    .startObject()
+                        .field("type", "rabbitmq")
+                        .startObject("rabbitmq")
+                            .field("queue", getDbName())
+                        .endObject()
+                        .startObject("script_filter")
+                            .field("script", "ctx.bulkindextype = _index + '#' + _type; ctx.lengthid = (_id != null ? _id.length() : 0)")
+                        .endObject()
+                        .startObject("index")
+                            .field("ordered", true)
+                        .endObject()
+                    .endObject(), 3, 10, null, true, true);
+
+        // We should have data we don't have without raw set to true
+        SearchResponse response = client().prepareSearch(getDbName())
+                .addField("bulkindextype")
+                .addField("lengthid")
+                .get();
+
+        logger.info("  --> Search response: {}", response.toString());
+
+        for (SearchHit hit : response.getHits().getHits()) {
+            assertThat(hit.field("bulkindextype"), notNullValue());
+            assertThat(hit.field("bulkindextype").<String>getValue(), equalTo(hit.getIndex() + "#" + hit.getType()));
+
+            assertThat(hit.field("lengthid"), notNullValue());
+            assertThat(hit.field("lengthid").getValue(), instanceOf(Integer.class));
+            assertThat(hit.field("lengthid").<Integer>getValue(), equalTo(hit.getId().length()));
+        }
+
+    }
+
+    @Test
     public void testNativeScript() throws Exception {
         launchTest(jsonBuilder()
                 .startObject()


### PR DESCRIPTION
This commit adds some context variables coming from the action meta data of the bulk item to filter scripts: action, _index, _type, _id, _version, _parent etc.

Closes #84
Related to #83
